### PR TITLE
add ccusage v15.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27541,6 +27541,12 @@
     githubId = 33605526;
     name = "Yash Garg";
   };
+  yasunori0418 = {
+    email = "yasunori.kirin0418@gmail.com";
+    github = "yasunori0418";
+    githubId = "74786563";
+    name = "taiki watanabe";
+  };
   yavko = {
     name = "Yavor Kolev";
     email = "yavornkolev@gmail.com";

--- a/pkgs/by-name/cc/ccusage/package-lock.json
+++ b/pkgs/by-name/cc/ccusage/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "ccusage",
+  "version": "15.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ccusage",
+      "version": "15.2.0",
+      "bin": {
+        "ccusage": "dist/index.js"
+      }
+    }
+  }
+}

--- a/pkgs/by-name/cc/ccusage/package.nix
+++ b/pkgs/by-name/cc/ccusage/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchurl,
+}:
+
+buildNpmPackage rec {
+  pname = "ccusage";
+  version = "15.2.0";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/ccusage/-/ccusage-${version}.tgz";
+    hash = "sha256-rMRHWSeGN+xiKp89VF0NiKUWbBxFFWEO3nhSeQlq4DM=";
+  };
+
+  npmDepsHash = "sha256-RScXn3Ry2lVXc57Sj/4OM9h51ddcU/v6cSLi6ecp4r8=";
+  forceEmptyCache = true;
+
+  postPatch = ''
+    cp ${./package-lock.json} package-lock.json
+  '';
+
+  dontNpmBuild = true;
+  dontNpmInstall = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/ccusage
+    cp -r * $out/lib/node_modules/ccusage/
+
+    mkdir -p $out/bin
+    ln -s $out/lib/node_modules/ccusage/dist/index.js $out/bin/ccusage
+    chmod +x $out/lib/node_modules/ccusage/dist/index.js
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Create a temporary mock Claude data directory structure for testing
+    export TMPDIR_CLAUDE=$(mktemp -d)
+    mkdir -p "$TMPDIR_CLAUDE/projects"
+
+    # Set CLAUDE_CONFIG_DIR to point to our mock directory
+    export CLAUDE_CONFIG_DIR="$TMPDIR_CLAUDE"
+
+    # Test that the binary exists and can show help
+    $out/bin/ccusage --help > /dev/null
+    echo "ccusage help command executed successfully"
+
+    # Test version command if available
+    $out/bin/ccusage --version > /dev/null || echo "Version command not available, help test passed"
+
+    # Cleanup temporary directory
+    rm -rf "$TMPDIR_CLAUDE"
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "CLI tool for analyzing Claude Code token usage and costs from local JSONL files";
+    homepage = "https://ccusage.com";
+    changelog = "https://github.com/ryoppippi/ccusage/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yasunori0418 ];
+    mainProgram = "ccusage";
+  };
+}

--- a/pkgs/development/compilers/factor-lang/mk-vocab.nix
+++ b/pkgs/development/compilers/factor-lang/mk-vocab.nix
@@ -41,7 +41,7 @@ drvArgs:
             base=$(basename "${finalAttrs.vocabName}")
             root=''${fname%$base}
             root=''${root:-.}
-            find "$root" -mindepth 1 -maxdepth 1 -type -d \
+            find "$root" -mindepth 1 -maxdepth 1 -type d \
                 -not \( -name bin -or -name doc -or -name lib \) -exec \
                 cp -r -t "$out/lib/factor/${finalAttrs.vocabRoot}" {} \+
         else


### PR DESCRIPTION
Add ccusage package - CLI tool for analyzing Claude Code token usage and costs from local JSONL files.

ccusage is a TypeScript-based CLI tool that analyzes Claude Code usage data from local JSONL files stored in Claude data directories.
It provides daily, monthly, and session-based token usage reports with cost calculation and supports multiple output formats.

Homepage: https://ccusage.com
Repository: https://github.com/ryoppippi/ccusage


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
